### PR TITLE
Allow custom search result descriptions to appear

### DIFF
--- a/lib/google-site-search/result.rb
+++ b/lib/google-site-search/result.rb
@@ -1,12 +1,12 @@
 module GoogleSiteSearch
 
-	# A default class that parses a result element from 
+	# A default class that parses a result element from
 	# Googles search API.
 	#
 	# See {LibXML Ruby's Node}[http://libxml.rubyforge.org/rdoc/classes/LibXML/XML/Node.html] when writing your own Result class.
 	class Result
 		attr_reader :title, :link, :description
-		
+
 		# ==== Attributes
 		#
 		# * +node+ - LibXML::XML::Node.
@@ -17,6 +17,11 @@ module GoogleSiteSearch
 			@link = node.find_first("UE").try(:content)
 
 			@description = node.find_first("S").try(:content)
+
+      #check for custom search description when not regular search result
+      if @description.empty?
+        @description = node.find_first("//BLOCK /T").try(:content)
+      end
 		end
 	end
 end


### PR DESCRIPTION
In cases where there are featured search results, at present descriptions remains blank as the xml schema is different for featured items.
