### PR TITLE
Search local node for custom results

### DIFF
--- a/lib/google-site-search/result.rb
+++ b/lib/google-site-search/result.rb
@@ -20,7 +20,7 @@ module GoogleSiteSearch
 
       #check for custom search description when not regular search result
       if @description.empty?
-        @description = node.find_first("//BLOCK /T").try(:content)
+        @description = node.find_first(".//BLOCK /T").try(:content)
       end
 		end
 	end

--- a/lib/google-site-search/result.rb
+++ b/lib/google-site-search/result.rb
@@ -11,7 +11,6 @@ module GoogleSiteSearch
 		#
 		# * +node+ - LibXML::XML::Node.
 		def initialize(node)
-			@description = nil
 			@title = node.find_first("T").try(:content)
 
 			# Fully qualified URL to the result.

--- a/lib/google-site-search/result.rb
+++ b/lib/google-site-search/result.rb
@@ -11,6 +11,7 @@ module GoogleSiteSearch
 		#
 		# * +node+ - LibXML::XML::Node.
 		def initialize(node)
+			@description = nil
 			@title = node.find_first("T").try(:content)
 
 			# Fully qualified URL to the result.


### PR DESCRIPTION
Hey @GBH, apparently `//BLOCK` checks from the top of the XML schema rather from the local node, as such all custom results are showing the first custom result `.//`, checks descending nodes only.

Please Bundle Update on Telus once merged. Thanks!
